### PR TITLE
seq: test promise chain

### DIFF
--- a/coding-harder/seq.js
+++ b/coding-harder/seq.js
@@ -21,3 +21,18 @@ test(async t => {
   t.deepEqual(await seq([a, b, c]), ['a', 'b', 'c'])
   t.deepEqual(await seq([a, c, b]), ['a', 'c', 'b'])
 })
+
+test(async t => {
+
+  let delay = 100;
+  
+  let resolved = new Promise(res => setTimeout(res, delay))
+  let rejected = Promise.reject()
+
+  let start = Date.now()
+  try {
+    await seq([resolved, rejected])
+  } catch(e) {
+    t.true(Date.now() - start >= delay)
+  }
+})

--- a/coding-harder/seq.js
+++ b/coding-harder/seq.js
@@ -1,13 +1,11 @@
 /// solution
 
-async function seq([promise, ...promises]) {
-  if (!promise) {
-    return []
-  }
-  return [
-    await promise,
-    ...await seq(promises)
-  ]
+async function seq(funcs) {
+    let res;
+    for (let f of funcs) {
+        res = await f(res);
+    }
+    return res;
 }
 
 /// tests
@@ -15,24 +13,10 @@ async function seq([promise, ...promises]) {
 import { test } from 'ava'
 
 test(async t => {
-  let a = Promise.resolve('a')
-  let b = Promise.resolve('b')
-  let c = Promise.resolve('c')
-  t.deepEqual(await seq([a, b, c]), ['a', 'b', 'c'])
-  t.deepEqual(await seq([a, c, b]), ['a', 'c', 'b'])
-})
+    let a = async () => ['a']
+    let b = async (accum) => accum.concat(['b'])
+    let c = async (accum) => accum.concat(['c'])
 
-test(async t => {
-
-  let delay = 100;
-  
-  let resolved = new Promise(res => setTimeout(res, delay))
-  let rejected = Promise.reject()
-
-  let start = Date.now()
-  try {
-    await seq([resolved, rejected])
-  } catch(e) {
-    t.true(Date.now() - start >= delay)
-  }
+    t.deepEqual(await seq([a, b, c]), ['a', 'b', 'c'])
+    t.deepEqual(await seq([a, c, b]), ['a', 'c', 'b'])
 })


### PR DESCRIPTION
Current test checks if array contains promise results in same sequence as passed promises.  
Which is the same behavior as `Promise.all`

In both `Promise.all` and `seq` passed promises are resolved in parallel.  
But `seq` will wait promise resolutions sequentially (setting up promise chain), while `Promise.all` will wait all promises in parallel.

How can we check if promises are waited sequentially?  
Only one solution I have in mind: add rejected promise to the end of chain, and expect whole chain to reject *after* starting promises handled.  
`Promise.all` promise would reject immediately not waiting for starting promises.

Also suggesting to update original question.  

```
seq - Resolve an array of promises in sequence  
         (as opposed to Promise.all, which does it in parallel).

let a = Promise.resolve('a')
let b = Promise.resolve('b')
let c = Promise.resolve('c')
await seq([a, b, c])                  // ['a', 'b', 'c']
await seq([a, c, b])                  // ['a', 'c', 'b']
```

to

```
seq - Wait an array of promises in sequence
         (as opposed to Promise.all, which does it in parallel).

let resolved = new Promise(res => setTimeout(res, 100))
let rejected = Promise.reject()

await seq([resolved, rejected]) // rejected after 100ms, not immediately as Promise.all
```

This is a bit heavier, but much closer to what makes `seq` uniq over `Promise.all`