### PR TITLE
add memoization

### DIFF
--- a/coding-easy/fib.js
+++ b/coding-easy/fib.js
@@ -8,6 +8,17 @@ function fib (n) {
   }
 }
 
+function memoize(fn) {
+  const memo = {};
+
+  return function(...args) {
+    if (!memo[args]) memo[args] = fn(...args);
+    return memo[args];
+  }
+}
+
+fib = memoize(fib);
+
 /// tests
 
 import { test } from 'ava'


### PR DESCRIPTION
Without memoization, the function is too slow for larger numbers , e.g. try `fib(42)`.